### PR TITLE
Remove bonus feature cards from landing page

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -118,7 +118,7 @@ export default function LandingPage() {
           initial={{ opacity: 0, y: 40 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.9, duration: 0.8 }}
-          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 max-w-7xl w-full"
+          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 max-w-7xl w-full"
         >
           {[
             {
@@ -144,48 +144,6 @@ export default function LandingPage() {
               title: 'Easy to Try',
               description: 'Get started quickly with our streamlined interface',
               category: 'required'
-            },
-            {
-              icon: '📎',
-              title: 'Attachment Support',
-              description: 'Upload and analyze files including images and PDFs',
-              category: 'bonus'
-            },
-            {
-              icon: '🎨',
-              title: 'Syntax Highlighting',
-              description: 'Beautiful code formatting and syntax highlighting',
-              category: 'bonus'
-            },
-            {
-              icon: '🌳',
-              title: 'Chat Branching',
-              description: 'Create alternative conversation paths from any message',
-              category: 'bonus'
-            },
-            {
-              icon: '⏸️',
-              title: 'Resumable Streams',
-              description: 'Continue AI generation after page refresh',
-              category: 'bonus'
-            },
-            {
-              icon: '🔗',
-              title: 'Chat Sharing',
-              description: 'Share conversations with others easily',
-              category: 'bonus'
-            },
-            {
-              icon: '🔑',
-              title: 'Bring Your Own Key',
-              description: 'Use your own API keys for full control',
-              category: 'bonus'
-            },
-            {
-              icon: '🎆',
-              title: 'Anything Else',
-              description: 'Get creative - we love unique ideas and feedback!',
-              category: 'bonus'
             }
           ].map((feature, index) => (
             <motion.div


### PR DESCRIPTION
## Summary
- Removed all bonus feature cards from the landing page
- Now only displays the 4 core required features: LLM support, authentication, browser friendly, and easy to try
- Adjusted grid layout to properly display the remaining cards

## Changes
- Removed chat branching, resumable streams, attachment support, syntax highlighting, chat sharing, BYOK, and other bonus feature cards
- Updated grid classes from `lg:grid-cols-3 xl:grid-cols-4` to `lg:grid-cols-4` for better layout with 4 cards

## Test plan
- [ ] View landing page and verify only 4 core feature cards are displayed
- [ ] Check responsive layout on different screen sizes
- [ ] Ensure grid layout looks balanced with 4 cards